### PR TITLE
Adds Kill command w/ channel subcommand

### DIFF
--- a/lnt/cli.py
+++ b/lnt/cli.py
@@ -4,6 +4,7 @@ from lnt.constants import DEFAULT_DIR_PATH, DEFAULT_MONTHS_AGO
 from lnt.utils import *
 from lnt.commands import create as cmd_create
 from lnt.commands import view as cmd_view
+from lnt.commands.utils import utils
 
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='COMPLEX')
@@ -146,6 +147,8 @@ def channel(ctx, csv, monthsago, minlocalbalpercentage, maxlocalbalpercentage,
     ctx.maxremotebalpercentage = maxremotebalpercentage
     ctx.minchannelswithpeer = minchannelswithpeer
     ctx.maxchannelswithpeer = maxchannelswithpeer
+
+    ctx.stub, ctx.macaroon = utils.create_stub(ctx)
 
     if monthsago:
         ctx.monthsago = monthsago

--- a/lnt/cli.py
+++ b/lnt/cli.py
@@ -75,8 +75,12 @@ def main(ctx, config, verbose):
     # Config validation
     try:
         config.read(config_path)
-        validate_config(config)
-    except ParsingError:
+        config, passed = validate_config(config)
+
+        if not passed:
+            raise Exception
+
+    except Exception:
         raise Exception("Invalid config file provided")
 
     ctx.config = config

--- a/lnt/cli.py
+++ b/lnt/cli.py
@@ -1,9 +1,11 @@
 import os, sys, click
+from decimal import Decimal
 from configparser import ParsingError, ConfigParser
 from lnt.constants import DEFAULT_DIR_PATH, DEFAULT_MONTHS_AGO
 from lnt.utils import *
 from lnt.commands import create as cmd_create
 from lnt.commands import view as cmd_view
+from lnt.commands import kill as cmd_kill
 from lnt.commands.utils import utils
 
 
@@ -164,3 +166,27 @@ def channel(ctx, csv, monthsago, minlocalbalpercentage, maxlocalbalpercentage,
 
     cmd_view.channel(ctx)
     return
+
+@main.group()
+@click.pass_context
+def kill(ctx):
+    """ Kill channels """
+    return
+
+@kill.command()
+@click.option('--id', metavar='CHANNEL_ID', help="Close by channel id", type=int)
+@click.option('-f', is_flag=True, help="Closes a channel uncooperatively ( force close )")
+@click.option('--streaming', '-s', is_flag=True, help="Listens for updates on the closed channel")
+@click.option('--target_conf', metavar='NUM_BLOCKS', help="Target confirmation blocks", type=int)
+@click.option('--sat_per_byte', metavar='SATS', help="Feerate in satoshis per byte for closing tx", type=Decimal)
+@click.pass_context
+def channel(ctx, id, f, streaming, target_conf, sat_per_byte):
+    ctx.channel_id = id
+    ctx.force = f
+    ctx.streaming = streaming
+    ctx.target_conf = target_conf
+    ctx.sat_per_byte = sat_per_byte
+    ctx.stub, ctx.macaroon = utils.create_stub(ctx)
+
+    cmd_kill.channel(ctx)
+

--- a/lnt/commands/create.py
+++ b/lnt/commands/create.py
@@ -5,7 +5,7 @@ import os, codecs, argparse
 # Mark 3rd party lib imports
 import lnt.rpc.rpc_pb2 as ln, lnt.rpc.rpc_pb2_grpc as lnrpc
 from PyInquirer import style_from_dict, Token, prompt, Separator
-import click, grpc
+import click
 
 # Mark Local imports
 from .utils import utils, rebal

--- a/lnt/commands/kill.py
+++ b/lnt/commands/kill.py
@@ -1,0 +1,41 @@
+# Mark 3rd party imports
+import click
+
+# Mark Local imports
+import lnt.rpc.rpc_pb2 as ln
+from lnt.rpc.api import getChanInfo, closeChannel
+from .utils import utils
+
+
+def channel(ctx):
+    testnet = ctx.parent.parent.config['LNT']['testnet']
+    chan_info = getChanInfo(ctx, ctx.channel_id)
+    funding_txid, output_index = chan_info['chan_point'].split(':')
+
+    channel_point = ln.ChannelPoint(
+        funding_txid_str=funding_txid,
+        output_index=int(output_index)
+    )
+
+    closing_tx = None
+    try:
+        closing_tx = closeChannel(ctx, channel_point, streaming=ctx.streaming, force=ctx.force, target_conf=ctx.target_conf, sat_per_byte=ctx.sat_per_byte)
+    except Exception as error:
+        if "unable to gracefully close channel while peer is offline" in str(error):
+            click.echo("Error: Peer is offline, rerun with -f")
+        elif "channel is already in the process of being force closed" in str(error):
+            click.echo("Warning: Channel is already in the process of being force closed")
+        elif "force closing a channel uses a pre-defined fee" in str(error):
+            click.echo("Force closing uses a pre-defined fee. Closing of channel abandoned")
+        else:
+            click.echo("Unhandled Error: " + str(error))
+        return
+    
+    if not ctx.streaming:
+        click.echo(
+        "Closing Tx Confirming: {}\nView it here: https://blockstream.info{}{}"\
+            .format(closing_tx, '/testnet/' if testnet else '/', closing_tx))
+
+    return
+    
+

--- a/lnt/commands/view.py
+++ b/lnt/commands/view.py
@@ -3,7 +3,7 @@ import time, datetime, calendar
 from decimal import Decimal
 
 # Mark 3rd party lib imports
-import click, grpc
+import click
 
 # Mark Local imports
 from lnt.rpc.api import listChannels, getChanInfo, getForwardingHistory

--- a/lnt/rpc/api.py
+++ b/lnt/rpc/api.py
@@ -1,4 +1,5 @@
 # Mark 3rd party lib imports
+import click
 import lnt.rpc.rpc_pb2 as ln, lnt.rpc.rpc_pb2_grpc as lnrpc
 
 # Mark local imports

--- a/lnt/rpc/api.py
+++ b/lnt/rpc/api.py
@@ -2,31 +2,29 @@
 import lnt.rpc.rpc_pb2 as ln, lnt.rpc.rpc_pb2_grpc as lnrpc
 
 # Mark local imports
-from .utils import utils, rebal
+from lnt.commands.utils import utils, rebal
 
-STUB, MACAROON = utils.create_stub(ctx)
-
-def listChannels(active_only:bool=False):
+def listChannels(ctx, active_only:bool=False):
     request = ln.ListChannelsRequest(active_only=False)
-    response = STUB.ListChannels(request, metadata=[('macaroon', MACAROON)])
+    response = ctx.stub.ListChannels(request, metadata=[('macaroon', ctx.macaroon)])
     channels = utils.normalize_channels(response.channels)
 
     return channels
 
-def getChanInfo(chan_id: int):
+def getChanInfo(ctx, chan_id: int):
     request = ln.ChanInfoRequest(chan_id=chan_id)
-    response = STUB.GetChanInfo(request, metadata=[('macaroon', MACAROON)])
+    response = ctx.stub.GetChanInfo(request, metadata=[('macaroon', ctx.macaroon)])
     chan_info = utils.normalize_get_chan_response(response)
 
     return chan_info
 
-def getForwardingHistory(start_time, end_time, num_max_events=10000):
+def getForwardingHistory(ctx, start_time, end_time, num_max_events=10000):
     request = ln.ForwardingHistoryRequest(
         start_time=start_time,
         end_time=end_time,
         num_max_events=num_max_events
     )
-    response = stub.ForwardingHistory(request, metadata=[('macaroon', macaroon)])
+    response = ctx.stub.ForwardingHistory(request, metadata=[('macaroon', ctx.macaroon)])
 
     return tuple(response.forwarding_events)
 

--- a/lnt/utils.py
+++ b/lnt/utils.py
@@ -37,7 +37,13 @@ def validate_config(config):
         passed = False
         raise click.ClickException("Required parameter 'Host' not found in conf")
 
+    if 'testnet' in config['LNT']:
+        try:
+            config['LNT']['testnet'] = bool(config['LNT']['testnet'])
+        except Exception:
+            click.ClickException("testnet has to bool")
+
     if not passed:
        raise click.ClickException("Provided config file failed validation")
 
-    return passed
+    return config, passed


### PR DESCRIPTION
The kill command is to be used for situations synonymous with closing,
removing, deleting, or otherwise subtracting from the current situation.

The first subcommand to be added to `lnt kill` is channel, which allows
for the cooperative and uncooperative closing of channels by id, along
with some other tooling to help the tx along and view the tx on it's
journey into a block

closes #14 #18 